### PR TITLE
Adicionadas algumas formas de receber o access token via javascript

### DIFF
--- a/front-b/index.html
+++ b/front-b/index.html
@@ -77,7 +77,9 @@
     <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
     <script src="js/app.js"></script>
     <script>
-        $(document).ready(() => new App);
+        var app = null;
+
+        $(document).ready(_ => app = new App);
     </script>
 </body>
 </html>

--- a/sp-b/app/Http/Controllers/AccessTokenController.php
+++ b/sp-b/app/Http/Controllers/AccessTokenController.php
@@ -20,12 +20,17 @@ class AccessTokenController extends Controller
             return response("não autenticado", 400);
         }
 
-        return response(AccessTokenModel::newToSession())
+        $token = AccessTokenModel::newToSession();
+
+        return response()
+            ->view('access_token', [
+                'access_token' => $token,
+            ])
             ->withCookie(
                 cookie(
                     name: 'access_token',
-                    value: AccessTokenModel::newToSession(),
-                    minutes: 29,
+                    value: $token,
+                    minutes: 1,
                     raw: true,
                     httpOnly: false
                 )

--- a/sp-b/resources/views/access_token.blade.php
+++ b/sp-b/resources/views/access_token.blade.php
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Access Token</title>
+</head>
+<body>
+    <code id="access_token">{!! json_encode($access_token) !!}</code>
+    <script>
+        document.domain="saml.sp-b"
+
+        var token = @json($access_token);
+
+        (function(){
+            window.parent.app.remoteAccessToken(token);
+        })();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Adicionados mais exemplos de como receber o access token no javascript.

Além do uso de Cookies, pode ser utilizado o conteúdo da janela do backend, bem como receber uma chamada ativa do backend no front.